### PR TITLE
Update elasticsearch hosts to using whole string instead of splitting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,10 +12,9 @@ graylog_root_password_sha2: CHANGEME
 
 graylog_all_in_one: false
 
-graylog_elasticsearch_port: 9200
-
-# If set {}, Default to localhost
+# If set {}, Default to localhost:9200
 graylog_elasticsearch_hosts: {}
-  # - YOUR_ELASTICSEARCH_HOST_1
-  # - YOUR_ELASTICSEARCH_HOST_2
-  # - YOUR_ELASTICSEARCH_HOST_3
+  # - http://YOUR_ELASTICSEARCH_HOST_2:9200
+  # - http://YOUR_ELASTICSEARCH_HOST_2:9200
+  # - http://YOUR_ELASTICSEARCH_HOST_3:9200
+

--- a/tasks/graylog_post.yml
+++ b/tasks/graylog_post.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set fact variable for list each items
   set_fact:
-    graylog_elasticsearch_facts: "http://{{ item }}:{{ graylog_elasticsearch_port }}"
+    graylog_elasticsearch_facts: "{{ item }}"
   with_items: "{{ graylog_elasticsearch_hosts }}"
   register: graylog_elasticsearch_facts_output
 


### PR DESCRIPTION
Some elasticsearch server might using HTTPS on 443 instead of default port. This will make sure there isn't any complication with insert elasticsearch server string.