### PR TITLE
Add CentOS/RHEL support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,11 @@
 ---
+graylog_version: 3.1
+graylog_package_name: graylog-server
+graylog_service_name: graylog-server
+
+graylog_deb_url: https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.deb
+graylog_rpm_url: https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.rpm
+
 graylog_search_config_path: "{{ playbook_dir }}/files/groups/{{ item }}/graylog"
 graylog_search_config_paths: []
 
@@ -9,12 +16,15 @@ graylog_config_template_path: "{{ playbook_dir }}/roles/{{ role_name }}/template
 
 graylog_password_secret: CHANGEME
 graylog_root_password_sha2: CHANGEME
+graylog_min_heap_size: 1g
+graylog_max_heap_size: 1g
+graylog_java_options: "-Xms{{ graylog_min_heap_size }} -Xmx{{ graylog_max_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
+graylog_server_arguments: ""
 
 graylog_all_in_one: false
 
-# If set {}, Default to localhost:9200
+# If set {}, Default to {{ ansible_default_ipv4.address }}:9200
 graylog_elasticsearch_hosts: {}
   # - http://YOUR_ELASTICSEARCH_HOST_2:9200
   # - http://YOUR_ELASTICSEARCH_HOST_2:9200
   # - http://YOUR_ELASTICSEARCH_HOST_3:9200
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,10 @@ galaxy_info:
     versions:
     - trusty
     - xenial
+    - bionic
+  - name: EL
+    versions:
+    - 7
   galaxy_tags:
     - log
     - graylog

--- a/tasks/graylog_install.yml
+++ b/tasks/graylog_install.yml
@@ -1,12 +1,19 @@
 ---
-- name: Install Graylog
+- name: Install Graylog (Ubuntu/Debian)
   apt:
-    name: "{{ graylog_apt_package }}"
+    name: "{{ graylog_package_name }}"
     state: present
     update_cache: yes
+  when: ansible_os_family == 'Debian'
 
-- name: Ensure service enable
+- name: Install Graylog (CentOS/RHEL)
+  yum:
+    name: "{{ graylog_package_name }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure service is enabled
   service:
-    name: graylog-server
+    name: "{{ graylog_service_name }}"
     enabled: yes
     state: started

--- a/tasks/graylog_post.yml
+++ b/tasks/graylog_post.yml
@@ -21,24 +21,31 @@
   changed_when: yes
   notify: Restart Graylog
 
-- name: Pre-Check Graylog configuration file in template file
-  stat:
-    path: "{{ graylog_config_template_path }}"
-  register: graylog_config_template_output
-  run_once: yes
-  delegate_to: 127.0.0.1
-
-- name: Validate Graylog configuration file exists
-  assert:
-    that: graylog_config_template_output.stat.exists == true
-    msg: "No server.conf.j2 in template directory"
-
-- name: Copy Graylog configuration file in case of host doesn't have config file
+- name: Copy Graylog configuration file
   template:
     src: server.conf.j2
     dest: "{{ graylog_config_file_path }}"
     owner: root
     group: root
     mode: 0644
-  when: not graylog_config_check.stat.exists
+  notify: Restart Graylog
+
+- name: Copy Graylog default configuration file (Ubuntu/Debian)
+  template:
+    src: graylog.default.j2
+    dest: /etc/default/graylog-server
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_os_family == 'Debian'
+  notify: Restart Graylog
+
+- name: Copy Graylog default configuration file (CentOS/RHEL)
+  template:
+    src: graylog.default.j2
+    dest: /etc/sysconfig/graylog-server
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_os_family == 'RedHat'
   notify: Restart Graylog

--- a/tasks/graylog_pre.yml
+++ b/tasks/graylog_pre.yml
@@ -1,4 +1,10 @@
 ---
-- name: Install Graylog DEB repository
+- name: Install Graylog repository (Ubuntu/Debian)
   apt:
     deb: "{{ graylog_deb_url }}"
+  when: ansible_os_family == 'Debian'
+
+- name: Install Graylog repository (CentOS/RHEL)
+  yum:
+    name: "{{ graylog_rpm_url }}"
+  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Include OS family specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_os_family }}.yml"
-
 - include_tasks: graylog_pre.yml
 - include_tasks: graylog_install.yml
 

--- a/templates/graylog.default.j2
+++ b/templates/graylog.default.j2
@@ -1,0 +1,12 @@
+# Path to the java executable.
+JAVA=/usr/bin/java
+
+# Default Java options for heap and garbage collection.
+GRAYLOG_SERVER_JAVA_OPTS="{{ graylog_java_options }}"
+
+# Pass some extra args to graylog-server. (i.e. "-d" to enable debug mode)
+GRAYLOG_SERVER_ARGS="{{ graylog_server_arguments }}"
+
+# Program that will be used to wrap the graylog-server command. Useful to
+# support programs like authbind.
+GRAYLOG_COMMAND_WRAPPER=""

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -6,7 +6,7 @@
 # Characters that cannot be directly represented in this encoding can be written using Unicode escapes
 # as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
 # For example, \u002c.
-#
+# 
 # * Entries are generally expected to be a single line of the form, one of the following:
 #
 # propertyName=propertyValue
@@ -14,7 +14,7 @@
 #
 # * White space that appears between the property name and property value is ignored,
 #   so the following are equivalent:
-#
+# 
 # name=Stephen
 # name = Stephen
 #
@@ -34,11 +34,11 @@
 #         Los Angeles
 #
 #   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
-#
+# 
 # * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
-#
+# 
 # * The backslash character must be escaped as a double backslash. For example:
-#
+# 
 # path=c:\\docs\\doc1
 #
 
@@ -73,95 +73,109 @@ root_password_sha2 = {{ graylog_root_password_sha2 }}
 # Default is UTC
 #root_timezone = UTC
 
+# Set the bin directory here (relative or absolute)
+# This directory contains binaries that are used by the Graylog server.
+# Default: bin
+bin_dir = /usr/share/graylog-server/bin
+
+# Set the data directory here (relative or absolute)
+# This directory is used to store Graylog server state.
+# Default: data
+data_dir = /var/lib/graylog-server
+
 # Set plugin directory here (relative or absolute)
 plugin_dir = /usr/share/graylog-server/plugin
 
-# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
-# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
-rest_listen_uri = http://127.0.0.1:9000/api/
+###############
+# HTTP settings
+###############
 
-# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
-# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
-# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
-# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
-# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
-# the scheme, host name or URI.
-# This must not contain a wildcard address (0.0.0.0).
-#rest_transport_uri = http://192.168.1.1:9000/api/
+#### HTTP bind address
+#
+# The network interface used by the Graylog HTTP interface.
+#
+# This network interface must be accessible by all Graylog nodes in the cluster and by all clients
+# using the Graylog web interface.
+#
+# If the port is omitted, Graylog will use port 9000 by default.
+#
+# Default: 127.0.0.1:9000
+#http_bind_address = 127.0.0.1:9000
+#http_bind_address = [2001:db8::1]:9000
 
-# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+#### HTTP publish URI
+#
+# The HTTP URI of this Graylog node which is used to communicate with the other Graylog nodes in the cluster and by all
+# clients using the Graylog web interface.
+#
+# The URI will be published in the cluster discovery APIs, so that other Graylog nodes will be able to find and connect to this Graylog node.
+#
+# This configuration setting has to be used if this Graylog node is available on another network interface than $http_bind_address,
+# for example if the machine has multiple network interfaces or is behind a NAT gateway.
+#
+# If $http_bind_address contains a wildcard IPv4 address (0.0.0.0), the first non-loopback IPv4 address of this machine will be used.
+# This configuration setting *must not* contain a wildcard address!
+#
+# Default: http://$http_bind_address/
+#http_publish_uri = http://192.168.1.1:9000/
+
+#### External Graylog URI
+#
+# The public URI of Graylog which will be used by the Graylog web interface to communicate with the Graylog REST API.
+#
+# The external Graylog URI usually has to be specified, if Graylog is running behind a reverse proxy or load-balancer
+# and it will be used to generate URLs addressing entities in the Graylog REST API (see $http_bind_address).
+#
+# When using Graylog Collector, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
+#
+# This setting can be overriden on a per-request basis with the "X-Graylog-Server-URL" HTTP request header.
+#
+# Default: $http_publish_uri
+#http_external_uri =
+
+#### Enable CORS headers for HTTP interface
+#
+# This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
 # This is enabled by default. Uncomment the next line to disable it.
-#rest_enable_cors = false
+#http_enable_cors = false
 
-# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
+#### Enable GZIP support for HTTP interface
+#
+# This compresses API responses and therefore helps to reduce
 # overall round trip times. This is enabled by default. Uncomment the next line to disable it.
-#rest_enable_gzip = false
-
-# Enable HTTPS support for the REST API. This secures the communication with the REST API with
-# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
-# next line to enable it.
-#rest_enable_tls = true
-
-# The X.509 certificate chain file in PEM format to use for securing the REST API.
-#rest_tls_cert_file = /path/to/graylog.crt
-
-# The PKCS#8 private key file in PEM format to use for securing the REST API.
-#rest_tls_key_file = /path/to/graylog.key
-
-# The password to unlock the private key used for securing the REST API.
-#rest_tls_key_password = secret
+#http_enable_gzip = false
 
 # The maximum size of the HTTP request headers in bytes.
-#rest_max_header_size = 8192
+#http_max_header_size = 8192
 
-# The size of the thread pool used exclusively for serving the REST API.
-#rest_thread_pool_size = 16
+# The size of the thread pool used exclusively for serving the HTTP interface.
+#http_thread_pool_size = 16
+
+################
+# HTTPS settings
+################
+
+#### Enable HTTPS support for the HTTP interface
+#
+# This secures the communication with the HTTP interface with TLS to prevent request forgery and eavesdropping.
+#
+# Default: false
+#http_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the HTTP interface.
+#http_tls_cert_file = /path/to/graylog.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the HTTP interface.
+#http_tls_key_file = /path/to/graylog.key
+
+# The password to unlock the private key used for securing the HTTP interface.
+#http_tls_key_password = secret
+
 
 # Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
 # header. May be subnets, or hosts.
 #trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
-
-# Enable the embedded Graylog web interface.
-# Default: true
-#web_enable = false
-
-# Web interface listen URI.
-# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
-# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
-#web_listen_uri = http://127.0.0.1:9000/
-
-# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
-# Default: $rest_transport_uri
-#web_endpoint_uri =
-
-# Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
-# If these are disabled, modern browsers will not be able to retrieve resources from the server.
-#web_enable_cors = false
-
-# Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
-# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
-#web_enable_gzip = false
-
-# Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
-# using TLS to prevent request forgery and eavesdropping.
-# This is disabled by default. Uncomment the next line to enable it and see the other related configuration settings.
-#web_enable_tls = true
-
-# The X.509 certificate chain file in PEM format to use for securing the web interface.
-#web_tls_cert_file = /path/to/graylog-web.crt
-
-# The PKCS#8 private key file in PEM format to use for securing the web interface.
-#web_tls_key_file = /path/to/graylog-web.key
-
-# The password to unlock the private key used for securing the web interface.
-#web_tls_key_password = secret
-
-# The maximum size of the HTTP request headers in bytes.
-#web_max_header_size = 8192
-
-# The size of the thread pool used exclusively for serving the web interface.
-#web_thread_pool_size = 16
 
 # List of Elasticsearch hosts Graylog should connect to.
 # Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
@@ -172,7 +186,7 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 {% if graylog_elasticsearch_host_list %}
 elasticsearch_hosts = {{ ",".join(graylog_elasticsearch_host_list) }}
 {% else %}
-elasticsearch_hosts = http://localhost:{{ graylog_elasticsearch_port }}
+elasticsearch_hosts = http://{{ ansible_default_ipv4.address }}:9200
 {% endif %}
 
 # Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
@@ -240,6 +254,9 @@ elasticsearch_hosts = http://localhost:{{ graylog_elasticsearch_port }}
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 rotation_strategy = count
 
 # (Approximate) maximum number of documents in an Elasticsearch index before a new index
@@ -248,6 +265,9 @@ rotation_strategy = count
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_max_docs_per_index = 20000000
 
 # (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
@@ -256,6 +276,9 @@ elasticsearch_max_docs_per_index = 20000000
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_size_per_index = 1073741824
 
 # (Approximate) maximum time before a new Elasticsearch index is being created, also see
@@ -271,6 +294,9 @@ elasticsearch_max_docs_per_index = 20000000
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_time_per_index = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
@@ -284,6 +310,9 @@ elasticsearch_max_docs_per_index = 20000000
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_max_number_of_indices = 20
 
 # Decide what happens with the oldest indices when the maximum number of indices is reached.
@@ -293,11 +322,17 @@ elasticsearch_max_number_of_indices = 20
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 retention_strategy = delete
 
 # How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_shards = 4
 elasticsearch_replicas = 0
 
@@ -305,6 +340,9 @@ elasticsearch_replicas = 0
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_index_prefix = graylog
 
 # Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
@@ -312,6 +350,9 @@ elasticsearch_index_prefix = graylog
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_template_name = graylog-internal
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
@@ -329,6 +370,9 @@ allow_highlighting = false
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_analyzer = standard
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
@@ -349,6 +393,11 @@ elasticsearch_analyzer = standard
 # is being purged from the database.
 # Default: 1h
 #index_ranges_cleanup_interval = 1h
+
+# Time interval for the job that runs index field type maintenance tasks like cleaning up stale entries. This doesn't
+# need to run very often.
+# Default: 1h
+#index_field_type_periodical_interval = 1h
 
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
@@ -494,21 +543,29 @@ mongodb_max_connections = 1000
 # http://api.mongodb.com/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
 mongodb_threads_allowed_to_block_multiplier = 5
 
-# Drools Rule File (Use to rewrite incoming log messages)
-# See: http://docs.graylog.org/en/2.1/pages/drools.html
-#rules_file = /etc/graylog/server/rules.drl
 
 # Email transport
 #transport_email_enabled = false
 #transport_email_hostname = mail.example.com
 #transport_email_port = 587
 #transport_email_use_auth = true
-#transport_email_use_tls = true
-#transport_email_use_ssl = true
 #transport_email_auth_username = you@example.com
 #transport_email_auth_password = secret
 #transport_email_subject_prefix = [graylog]
 #transport_email_from_email = graylog@example.com
+
+# Encryption settings
+#
+# ATTENTION:
+#    Using SMTP with STARTTLS *and* SMTPS at the same time is *not* possible.
+
+# Use SMTP with STARTTLS, see https://en.wikipedia.org/wiki/Opportunistic_TLS
+#transport_email_use_tls = true
+
+# Use SMTP over SSL (SMTPS), see https://en.wikipedia.org/wiki/SMTPS
+# This is deprecated on most SMTP services!
+#transport_email_use_ssl = true
+
 
 # Specify and uncomment this if you want to include links to the stream in your stream alert mails.
 # This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
@@ -530,7 +587,20 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #http_write_timeout = 10s
 
 # HTTP proxy for outgoing HTTP connections
+# ATTENTION: If you configure a proxy, make sure to also configure the "http_non_proxy_hosts" option so internal
+#            HTTP connections with other nodes does not go through the proxy.
+# Examples:
+#   - http://proxy.example.com:8123
+#   - http://username:password@proxy.example.com:8123
 #http_proxy_uri =
+
+# A list of hosts that should be reached directly, bypassing the configured proxy server.
+# This is a list of patterns separated by ",". The patterns may start or end with a "*" for wildcards.
+# Any host matching one of these patterns will be reached through a direct connection instead of through a proxy.
+# Examples:
+#   - localhost,127.0.0.1
+#   - 10.0.*,*.example.com
+#http_non_proxy_hosts =
 
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
@@ -538,6 +608,9 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #disable_index_optimization = true
 
 # Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
@@ -545,6 +618,9 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #index_optimization_max_num_segments = 1
 
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
@@ -560,18 +636,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
 #dashboard_widget_default_cache_time = 10s
 
-# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
-#content_packs_loader_enabled = true
-
-# The directory which contains content packs which should be loaded on the first start of Graylog.
-content_packs_dir = /usr/share/graylog-server/contentpacks
-
-# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
-# the first start of Graylog.
-# Default: empty
-content_packs_auto_load = grok-patterns.json
-
 # For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
-# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+# Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
 proxied_requests_thread_pool_size = 32

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,0 @@
----
-graylog_apt_package: graylog-server
-graylog_deb_url: https://packages.graylog2.org/repo/packages/graylog-2.5-repository_latest.deb


### PR DESCRIPTION
- Remove specific OS vars file
- Update Graylog version to 3.1
- Update config template to version 3.1
  - Include new default config for adjusting java options
- Add CentOS/RHEL OS support
- Update variables for Ubuntu/Debian & CentOS/RHEL
  - New adjustable heap size and java options variables
  - All in one elasticsearch install will be point at `{{ ansible_default_ipv4.address }}:9200`
- Update conditions and tasks naming
- Update meta for bionic & RHEL