### PR TITLE
Update Graylog version 4.2.6 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,15 @@
 ---
 graylog_all_in_one: false
 
-graylog_version: 3.1
+graylog_version: 4.2
 graylog_package_name: graylog-server
 graylog_service_name: graylog-server
+graylog_jre_version: 17
+graylog_dependencies:
+  - apt-transport-https
+  - openjdk-{{ graylog_jre_version }}-jre-headless
+  - uuid-runtime
+  - pwgen
 
 graylog_search_config_path: "{{ playbook_dir }}/files/groups/{{ item }}/graylog"
 graylog_search_config_paths: []
@@ -20,7 +26,7 @@ graylog_root_password: CHANGEME
 graylog_timezone: Asia/Bangkok
 graylog_min_heap_size: 1g
 graylog_max_heap_size: 1g
-graylog_java_options: "-Xms{{ graylog_min_heap_size }} -Xmx{{ graylog_max_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
+graylog_java_options: "-Xms{{ graylog_min_heap_size }} -Xmx{{ graylog_max_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
 graylog_server_arguments: ""
 
 # Set Graylog http access
@@ -59,3 +65,7 @@ graylog_yum_repo_template: graylog.repo.j2
 graylog_change_install_path: false
 graylog_data_path: /var/lib/graylog-server
 graylog_default_dir: /usr/share/graylog-server
+
+# Prometheus
+graylog_prometheus_exporter_enabled: false
+graylog_prometheus_exporter_bind_address: 127.0.0.1:9833

--- a/tasks/graylog_pre.yml
+++ b/tasks/graylog_pre.yml
@@ -7,11 +7,11 @@
 - name: Install Graylog repository (CentOS/RHEL)
   yum:
     name: "{{ graylog_rpm_url }}"
-  when: 
+  when:
     - ansible_os_family == 'RedHat'
     - not graylog_offline_install
 
-- block: 
+- block:
   - name: Add Graylog repository file from template [RHEL/CentOS]
     template:
       src: "{{ graylog_yum_repo_template }}"
@@ -24,10 +24,12 @@
       src: "{{ graylog_gpg_key }}"
       dest: /etc/pki/rpm-gpg/
   when:
-    - ansible_pkg_mgr in ['yum', 'dnf'] 
+    - ansible_pkg_mgr in ['yum', 'dnf']
     - graylog_offline_install
 
-- name: Install pwgen
+- name: Install Graylog dependencies
   package:
-     name: "pwgen"
-     state: latest
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ graylog_dependencies }}"

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -6,7 +6,7 @@
 # Characters that cannot be directly represented in this encoding can be written using Unicode escapes
 # as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
 # For example, \u002c.
-# 
+#
 # * Entries are generally expected to be a single line of the form, one of the following:
 #
 # propertyName=propertyValue
@@ -14,7 +14,7 @@
 #
 # * White space that appears between the property name and property value is ignored,
 #   so the following are equivalent:
-# 
+#
 # name=Stephen
 # name = Stephen
 #
@@ -34,11 +34,11 @@
 #         Los Angeles
 #
 #   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
-# 
+#
 # * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
-# 
+#
 # * The backslash character must be escaped as a double backslash. For example:
-# 
+#
 # path=c:\\docs\\doc1
 #
 
@@ -58,6 +58,8 @@ node_id_file = /etc/graylog/server/node-id
 
 # You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
 # Generate one by using for example: pwgen -N 1 -s 96
+# ATTENTION: This value must be the same on all Graylog nodes in the cluster.
+# Changing this value after installation will render all user sessions and encrypted values in the database invalid. (e.g. encrypted access tokens)
 password_secret = {{ graylog_secret_system_password.stdout if graylog_secret_system_password.stdout is defined else graylog_secret_system_password['content'] | b64decode }}
 
 # The default root user is named 'admin'
@@ -145,9 +147,11 @@ http_external_uri = {{ graylog_http_external_uri }}
 
 #### Enable CORS headers for HTTP interface
 #
-# This is necessary for JS-clients accessing the server directly.
-# If these are disabled, modern browsers will not be able to retrieve resources from the server.
-# This is enabled by default. Uncomment the next line to disable it.
+# This allows browsers to make Cross-Origin requests from any origin.
+# This is disabled for security reasons and typically only needed if running graylog
+# with a separate server for frontend development.
+#
+# Default: false
 #http_enable_cors = false
 
 #### Enable GZIP support for HTTP interface
@@ -199,12 +203,23 @@ elasticsearch_hosts = {{ ",".join(graylog_elasticsearch_hosts) }}
 elasticsearch_hosts = http://{{ ansible_default_ipv4.address }}:9200
 {% endif %}
 
-# Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
+# Maximum number of retries to connect to elasticsearch on boot for the version probe.
+#
+# Default: 0, retry indefinitely with the given delay until a connection could be established
+#elasticsearch_version_probe_attempts = 5
+
+# Waiting time in between connection attempts for elasticsearch_version_probe_attempts
+#
+# Default: 5s
+#elasticsearch_version_probe_delay = 5s
+
+# Maximum amount of time to wait for successful connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds
 #elasticsearch_connect_timeout = 10s
 
 # Maximum amount of time to wait for reading back a response from an Elasticsearch server.
+# (e. g. during search, index creation, or index time-range calculations)
 #
 # Default: 60 seconds
 #elasticsearch_socket_timeout = 60s
@@ -217,14 +232,14 @@ elasticsearch_hosts = http://{{ ansible_default_ipv4.address }}:9200
 
 # Maximum number of total connections to Elasticsearch.
 #
-# Default: 20
-#elasticsearch_max_total_connections = 20
+# Default: 200
+#elasticsearch_max_total_connections = 200
 
 # Maximum number of total connections per Elasticsearch route (normally this means per
 # elasticsearch server).
 #
-# Default: 2
-#elasticsearch_max_total_connections_per_route = 2
+# Default: 20
+#elasticsearch_max_total_connections_per_route = 20
 
 # Maximum number of times Graylog will retry failed requests to Elasticsearch.
 #
@@ -250,23 +265,37 @@ elasticsearch_hosts = http://{{ ansible_default_ipv4.address }}:9200
 # Default: 30s
 # elasticsearch_discovery_frequency = 30s
 
+# Set the default scheme when connecting to Elasticsearch discovered nodes
+#
+# Default: http (available options: http, https)
+#elasticsearch_discovery_default_scheme = http
+
 # Enable payload compression for Elasticsearch requests.
 #
 # Default: false
 #elasticsearch_compression_enabled = true
 
-# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# Enable use of "Expect: 100-continue" Header for Elasticsearch index requests.
+# If this is disabled, Graylog cannot properly handle HTTP 413 Request Entity Too Large errors.
+#
+# Default: true
+#elasticsearch_use_expect_continue = true
+
+# Graylog will use multiple indices to store documents in. You can configure the strategy it uses to determine
 # when to rotate the currently active write index.
-# It supports multiple rotation strategies:
+# It supports multiple rotation strategies, the default being "count":
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
-# valid values are "count", "size" and "time", default is "count"
+#   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure
+# A strategy may be disabled by specifying the optional enabled_index_rotation_strategies list and excluding that strategy.
+#enabled_index_rotation_strategies = count,size,time
+
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 rotation_strategy = count
 
 # (Approximate) maximum number of documents in an Elasticsearch index before a new index
@@ -277,7 +306,7 @@ rotation_strategy = count
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 elasticsearch_max_docs_per_index = 20000000
 
 # (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
@@ -288,7 +317,7 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #elasticsearch_max_size_per_index = 1073741824
 
 # (Approximate) maximum time before a new Elasticsearch index is being created, also see
@@ -306,8 +335,11 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #elasticsearch_max_time_per_index = 1d
+
+# Optional upper bound on elasticsearch_max_time_per_index
+# elasticsearch_max_write_index_age = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
 # WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!
@@ -322,7 +354,7 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 elasticsearch_max_number_of_indices = 20
 
 # Decide what happens with the oldest indices when the maximum number of indices is reached.
@@ -334,7 +366,7 @@ elasticsearch_max_number_of_indices = 20
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 retention_strategy = delete
 
 # How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
@@ -342,7 +374,7 @@ retention_strategy = delete
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 elasticsearch_shards = 4
 elasticsearch_replicas = 0
 
@@ -352,7 +384,7 @@ elasticsearch_replicas = 0
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 elasticsearch_index_prefix = graylog
 
 # Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
@@ -362,11 +394,11 @@ elasticsearch_index_prefix = graylog
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #elasticsearch_template_name = graylog-internal
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
-# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
+# be enabled with care. See also: https://docs.graylog.org/docs/query-language
 allow_leading_wildcard_searches = false
 
 # Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
@@ -382,13 +414,8 @@ allow_highlighting = false
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 elasticsearch_analyzer = standard
-
-# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
-# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
-# Default: 1m
-#elasticsearch_request_timeout = 1m
 
 # Global timeout for index optimization (force merge) requests.
 # Default: 1h
@@ -398,6 +425,9 @@ elasticsearch_analyzer = standard
 # If you are using lots of different index sets, you might want to increase that number.
 # Default: 20
 #elasticsearch_index_optimization_jobs = 20
+
+# Mute the logging-output of ES deprecation warnings during REST calls in the ES RestClient
+#elasticsearch_mute_deprecation_warnings = true
 
 # Time interval for index range information cleanups. This setting defines how often stale index range information
 # is being purged from the database.
@@ -472,17 +502,17 @@ inputbuffer_ring_size = 65536
 inputbuffer_processors = 2
 inputbuffer_wait_strategy = blocking
 
-# Enable the disk based message journal.
+# Enable the message journal.
 message_journal_enabled = true
 
-# The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
+# The directory which will be used to store the message journal. The directory must be exclusively used by Graylog and
 # must not contain any other files than the ones created by Graylog itself.
 #
 # ATTENTION:
 #   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
 #   in the root directory, you need to create a sub directory for your journal.
 #   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
-message_journal_dir = /var/lib/graylog-server/journal
+message_journal_dir = {{ graylog_data_path }}/journal
 
 # Journal hold messages before they could be written to Elasticsearch.
 # For a maximum of 12 hours or 5 GB whichever happens first.
@@ -516,10 +546,6 @@ lb_recognition_period_seconds = 3
 #stream_processing_timeout = 2000
 #stream_processing_max_faults = 3
 
-# Length of the interval in seconds in which the alert conditions for all streams should be checked
-# and alarms are being sent.
-#alert_check_interval = 60
-
 # Since 0.21 the Graylog server supports pluggable output modules. This means a single message can be written to multiple
 # outputs. The next setting defines the timeout for a single output module, including the default output module where all
 # messages end up.
@@ -535,7 +561,6 @@ lb_recognition_period_seconds = 3
 
 # MongoDB connection string
 # See https://docs.mongodb.com/manual/reference/connection-string/ for details
-
 {% if graylog_mongodb_hosts %}
 mongodb_uri = mongodb://{{ graylog_mongodb_username }}:{{ graylog_mongodb_password }}@{{ ",".join(graylog_mongodb_hosts) }}/{{ graylog_mongodb_dbname }}?replicaSet={{ graylog_mongodb_replica_name }}&authSource={{ mongodb_admin_db_name }}
 {% else %}
@@ -543,10 +568,14 @@ mongodb_uri = mongodb://localhost/graylog
 {% endif %}
 
 # Authenticate against the MongoDB server
+# '+'-signs in the username or password need to be replaced by '%2B'
 #mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog
 
 # Use a replica set instead of a single host
-#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog?replicaSet=rs01
+
+# DNS Seedlist https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+#mongodb_uri = mongodb+srv://server.example.org/graylog
 
 # Increase this value according to the maximum connections your MongoDB server can handle from a single client
 # if you encounter MongoDB connection problems.
@@ -579,7 +608,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 
 # Use SMTP over SSL (SMTPS), see https://en.wikipedia.org/wiki/SMTPS
 # This is deprecated on most SMTP services!
-#transport_email_use_ssl = true
+#transport_email_use_ssl = false
 
 
 # Specify and uncomment this if you want to include links to the stream in your stream alert mails.
@@ -625,7 +654,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #disable_index_optimization = true
 
 # Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
@@ -635,7 +664,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #index_optimization_max_num_segments = 1
 
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
@@ -645,8 +674,8 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # Connection timeout for a configured LDAP server (e. g. ActiveDirectory) in milliseconds.
 #ldap_connection_timeout = 2000
 
-# Disable the use of SIGAR for collecting system stats
-#disable_sigar = false
+# Disable the use of a native system stats collector (currently OSHI)
+#disable_native_system_stats_collector = false
 
 # The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
 #dashboard_widget_default_cache_time = 10s
@@ -655,3 +684,72 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
 proxied_requests_thread_pool_size = 32
+
+# The server is writing processing status information to the database on a regular basis. This setting controls how
+# often the data is written to the database.
+# Default: 1s (cannot be less than 1s)
+#processing_status_persist_interval = 1s
+
+# Configures the threshold for detecting outdated processing status records. Any records that haven't been updated
+# in the configured threshold will be ignored.
+# Default: 1m (one minute)
+#processing_status_update_threshold = 1m
+
+# Configures the journal write rate threshold for selecting processing status records. Any records that have a lower
+# one minute rate than the configured value might be ignored. (dependent on number of messages in the journal)
+# Default: 1
+#processing_status_journal_write_rate_threshold = 1
+
+# Configures the prefix used for graylog event indices
+# Default: gl-events
+#default_events_index_prefix = gl-events
+
+# Configures the prefix used for graylog system event indices
+# Default: gl-system-events
+#default_system_events_index_prefix = gl-system-events
+
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+#content_packs_loader_enabled = false
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+#content_packs_dir = data/contentpacks
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+#content_packs_auto_install = grok-patterns.json
+
+# The allowed TLS protocols for system wide TLS enabled servers. (e.g. message inputs, http interface)
+# Setting this to an empty value, leaves it up to system libraries and the used JDK to chose a default.
+# Default: TLSv1.2,TLSv1.3  (might be automatically adjusted to protocols supported by the JDK)
+#enabled_tls_protocols= TLSv1.2,TLSv1.3
+
+# Enable Prometheus exporter HTTP server.
+# Default: false
+prometheus_exporter_enabled = {{ 'true' if graylog_prometheus_exporter_enabled else 'false' }}
+
+# IP address and port for the Prometheus exporter HTTP server.
+# Default: 127.0.0.1:9833
+#prometheus_exporter_bind_address = {{ graylog_prometheus_exporter_bind_address }}
+
+# Path to the Prometheus exporter core mapping file. If this option is enabled, the full built-in core mapping is
+# replaced with the mappings in this file.
+# This file is monitored for changes and updates will be applied at runtime.
+# Default: none
+#prometheus_exporter_mapping_file_path_core = prometheus-exporter-mapping-core.yml
+
+# Path to the Prometheus exporter custom mapping file. If this option is enabled, the mappings in this file are
+# configured in addition to the built-in core mappings. The mappings in this file cannot overwrite any core mappings.
+# This file is monitored for changes and updates will be applied at runtime.
+# Default: none
+#prometheus_exporter_mapping_file_path_custom = prometheus-exporter-mapping-custom.yml
+
+# Configures the refresh interval for the monitored Prometheus exporter mapping files.
+# Default: 60s
+#prometheus_exporter_mapping_file_refresh_interval = 60s
+
+# Optional allowed paths for Graylog data files. If provided, certain operations in Graylog will only be permitted
+# if the data file(s) are located in the specified paths (for example, with the CSV File lookup adapter).
+# All subdirectories of indicated paths are allowed by default. This Provides an additional layer of security,
+# and allows administrators to control where in the file system Graylog users can select files from.
+#allowed_auxiliary_paths = /etc/graylog/data-files,/etc/custom-allowed-path


### PR DESCRIPTION
* Use Graylog v4.2.6 as default.
* Use java runtime headless (jre) instead.
* Remove deprecated JVM options.
* Add [Prometheus enabling option](https://docs.graylog.org/docs/metrics).

Related to https://github.com/opsta/opsta-playbook/pull/64

References
* [Deprecated JVM options](https://github.com/Graylog2/graylog2-server/pull/10275)
* [Graylog v4.2.6 template file](https://github.com/Graylog2/graylog2-server/blob/4.2.6/misc/graylog.conf)